### PR TITLE
fix: add spread rest props to components

### DIFF
--- a/src/ui/box/box.lite.tsx
+++ b/src/ui/box/box.lite.tsx
@@ -54,5 +54,9 @@ export default function Box(props: BoxProps) {
     state.calculateStyles();
   }, [props]);
 
-  return <props.as className={state.className}>{props.children}</props.as>;
+  return (
+    <props.as {...props.attributes} className={state.className}>
+      {props.children}
+    </props.as>
+  );
 }

--- a/src/ui/box/box.types.ts
+++ b/src/ui/box/box.types.ts
@@ -6,6 +6,7 @@ export type BoxProps = Sprinkles & {
   className?: ClassValue;
   children?: any;
   forwardedRef?: any;
+  attributes?: any;
 };
 
 export const DEFAULT_VALUES = {

--- a/src/ui/button/Button.lite.tsx
+++ b/src/ui/button/Button.lite.tsx
@@ -2,6 +2,7 @@ import { onMount, Show, useMetadata, useStore } from "@builder.io/mitosis";
 import clx from "clsx";
 import { variants } from "./button.css";
 import Icon from "../icon";
+import Box from "../box";
 import { sprinkles as s } from "../../styles/sprinkles.css";
 import type { ButtonProps, ButtonState } from "./button.types";
 
@@ -18,9 +19,13 @@ export default function Button(props: ButtonProps) {
 
   return (
     <Show when={state.loaded}>
-      <button
-        onClick={(event) => props.onClick?.(event)}
-        disabled={props.disabled}
+      <Box
+        as="button"
+        {...props.attributes}
+        attributes={{
+          onClick: (event) => props.onClick?.(event),
+          disabled: props.disabled,
+        }}
         className={clx(
           variants({
             variant: props.variant,
@@ -51,7 +56,7 @@ export default function Button(props: ButtonProps) {
             })}
           />
         </Show>
-      </button>
+      </Box>
     </Show>
   );
 }

--- a/src/ui/button/Button.types.tsx
+++ b/src/ui/button/Button.types.tsx
@@ -1,5 +1,6 @@
 import { BaseComponentProps, BaseState } from "../../models/components.model";
 import type { Variants } from "./button.css";
+import type { BoxProps } from "../box/box.types";
 import type { IconProps } from "../icon/icon.types";
 
 export interface ButtonProps extends BaseComponentProps {
@@ -11,6 +12,7 @@ export interface ButtonProps extends BaseComponentProps {
   leftIcon?: IconProps["name"];
   rightIcon?: IconProps["name"];
   onClick?: (event: any) => void;
+  attributes?: BoxProps;
 }
 
 export interface ButtonState extends BaseState {}

--- a/src/ui/button/button.lite.tsx
+++ b/src/ui/button/button.lite.tsx
@@ -2,6 +2,7 @@ import { onMount, Show, useMetadata, useStore } from "@builder.io/mitosis";
 import clx from "clsx";
 import { variants } from "./button.css";
 import Icon from "../icon";
+import Box from "../box";
 import { sprinkles as s } from "../../styles/sprinkles.css";
 import type { ButtonProps, ButtonState } from "./button.types";
 
@@ -18,9 +19,13 @@ export default function Button(props: ButtonProps) {
 
   return (
     <Show when={state.loaded}>
-      <button
-        onClick={(event) => props.onClick?.(event)}
-        disabled={props.disabled}
+      <Box
+        as="button"
+        {...props.attributes}
+        attributes={{
+          onClick: (event) => props.onClick?.(event),
+          disabled: props.disabled,
+        }}
         className={clx(
           variants({
             variant: props.variant,
@@ -51,7 +56,7 @@ export default function Button(props: ButtonProps) {
             })}
           />
         </Show>
-      </button>
+      </Box>
     </Show>
   );
 }

--- a/src/ui/button/button.types.tsx
+++ b/src/ui/button/button.types.tsx
@@ -1,5 +1,6 @@
 import { BaseComponentProps, BaseState } from "../../models/components.model";
 import type { Variants } from "./button.css";
+import type { BoxProps } from "../box/box.types";
 import type { IconProps } from "../icon/icon.types";
 
 export interface ButtonProps extends BaseComponentProps {
@@ -11,6 +12,7 @@ export interface ButtonProps extends BaseComponentProps {
   leftIcon?: IconProps["name"];
   rightIcon?: IconProps["name"];
   onClick?: (event: any) => void;
+  attributes?: BoxProps;
 }
 
 export interface ButtonState extends BaseState {}

--- a/src/ui/stack/stack.lite.tsx
+++ b/src/ui/stack/stack.lite.tsx
@@ -4,6 +4,7 @@ import type { StackProps } from "./stack.types";
 export default function Stack(props: StackProps) {
   return (
     <Box
+      {...props.attributes}
       className={props.className}
       alignItems={props.align}
       as={props.as}

--- a/src/ui/stack/stack.types.tsx
+++ b/src/ui/stack/stack.types.tsx
@@ -10,4 +10,5 @@ export interface StackProps extends BoxProps {
   wrap?: OptionalResponsiveObject<true | false>;
   direction?: "row" | "column";
   className?: BoxProps["className"];
+  attributes?: BoxProps;
 }

--- a/src/ui/text/text.lite.tsx
+++ b/src/ui/text/text.lite.tsx
@@ -10,6 +10,7 @@ export default function Text(props: TextProps) {
 
   return (
     <Box
+      {...props.attributes}
       as={props.as}
       className={`${variants({
         variant: props.variant,
@@ -25,22 +26,6 @@ export default function Text(props: TextProps) {
       textTransform={props.transform}
       whiteSpace={props.whiteSpace}
       wordBreak={props.wordBreak}
-      mx={props.mx}
-      my={props.my}
-      px={props.px}
-      py={props.py}
-      marginBottom={props.marginBottom}
-      marginTop={props.marginTop}
-      marginLeft={props.marginLeft}
-      marginRight={props.marginRight}
-      paddingBottom={props.paddingBottom}
-      paddingTop={props.paddingTop}
-      paddingLeft={props.paddingLeft}
-      paddingRight={props.paddingRight}
-      width={props.width}
-      maxWidth={props.maxWidth}
-      height={props.height}
-      maxHeight={props.maxHeight}
     >
       {props.children}
     </Box>

--- a/src/ui/text/text.types.tsx
+++ b/src/ui/text/text.types.tsx
@@ -26,4 +26,5 @@ export interface TextProps extends BoxProps, Variants {
   wordBreak?: BoxProps["wordBreak"];
   underline?: boolean;
   className?: BoxProps["className"];
+  attributes?: BoxProps;
 }


### PR DESCRIPTION
Spread operator seems to be fixed in mitosis but only if it's an explicit prop, we will use `attributes` as an equivalent to `restProps`

```javascript
const { as, ...restProps } = props;
```