### PR TITLE
fix: Adding `referrerPolicy: "no-referrer"` to logo images.

### DIFF
--- a/src/ui/connect-modal-wallet-button/connect-modal-wallet-button.lite.tsx
+++ b/src/ui/connect-modal-wallet-button/connect-modal-wallet-button.lite.tsx
@@ -98,6 +98,7 @@ export default function ConnectModalWalletButton(
                 attributes={{
                   alt: props.name,
                   src: props.logo,
+                  referrerPolicy: "no-referrer",
                 }}
                 width={props.variant === "square" ? "$16" : "$12"}
                 height={props.variant === "square" ? "$16" : "$12"}


### PR DESCRIPTION
Some wallets feature a logo that won't resolve due to a 403 forbidden error. As an example, [the fin wallet has a logo](https://github.com/cosmology-tech/cosmos-kit/blob/98b369155102fdfb90a085ed5c2ecc8021553878/wallets/fin-extension/src/extension/registry.ts#L5) that points to:

> https://lh3.googleusercontent.com/oKvetnosutN7Q7daICbew7k9kLLB1unNlggkA-mZZZZIdNWp7vJFpz5q9MZ73Wlw5S5KrHV5mEQ0UEKYaDWz5qmacHw=w128-h128-e365-rj-sc0x00ffffff.

Visiting the URL for this image directly works just fine. However, when this URL is used in  `<img>` tag, a 403 forbidden error results. Here are some screenshots for reference:

| <img width="276" alt="image" src="https://github.com/cosmology-tech/interchain-ui/assets/1923767/e261c07f-30e9-4383-a2d7-151faa12a973"> | ![localhost_3000_collection_dob_2952](https://github.com/cosmology-tech/interchain-ui/assets/1923767/595e5661-a1f1-4437-856e-179f6cf1ec6f) |
| --- | --- |

This issue seems to have been resolved for some Chakra UI components (https://github.com/chakra-ui/chakra-ui/issues/5909) but not for the one used to render the logo for each wallet.

This PR adds the `referrerPolicy: "no-referrer"` to logo images so that wallets using images served by `googleusercontent.com` will render as intended.